### PR TITLE
Call to ngx.req.get_headers was missing parenthesis causing a crash in response

### DIFF
--- a/grpc-gateway/response.lua
+++ b/grpc-gateway/response.lua
@@ -36,7 +36,7 @@ _M.new = function(proto)
       -- Important:
       -- Strip first 5 bytes from response body to make sure pb.decode() works correctly
       -- But if request comes from gRPC-Web, this bytes are necessary for client...
-      if not ngx.req.get_headers["X-Grpc-Web"] then
+      if not ngx.req.get_headers()["X-Grpc-Web"] then
         buffer = string.sub(buffer, 6)
       end
 


### PR DESCRIPTION
After attempting to use your latest release and running your example I ran into the following issue.

```bash
curl -vvv -H "Content-Type: application/json" -d '{"name":"Testing"}' http://localhost:9000/rest
```

```
server_1   | 2019/08/05 09:14:42 name: Testing
gateway_1  | 172.20.0.1 - - [05/Aug/2019:09:14:42 +0000] "POST /rest HTTP/1.1" 200 0 "-" "curl/7.65.3"
gateway_1  | 2019/08/05 09:14:42 [error] 6#6: *1 failed to run body_filter_by_lua*: ...openresty/luajit/share/lua/5.1/grpc-gateway/response.lua:39: attempt to index field 'get_headers' (a function value)
gateway_1  | stack traceback:
gateway_1  | 	...openresty/luajit/share/lua/5.1/grpc-gateway/response.lua:39: in function 'transform'
gateway_1  | 	body_filter_by_lua:10: in main chunk while sending to client, client: 172.20.0.1, server: localhost, request: "POST /rest HTTP/1.1", upstream: "grpc://172.20.0.3:50001", host: "localhost:9000"
```

After some debugging found out that the call to `ngx.req.get_headers` requires a parenthesis. 
https://openresty-reference.readthedocs.io/en/latest/Lua_Nginx_API/#ngxreqget_headers
```
ngx.req.get_headers()["Foo"]
```
Adding the fix to the function call now produces the desired result. Hopefully we can get a new release with this fix included.
