### PR TITLE
Update example protoc

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,6 +1,6 @@
 FROM openresty/openresty:1.15.8.1rc1-xenial
 
-ARG PROTOC_VERSION="3.9.0"
+ARG PROTOC_VERSION="3.11.0"
 
 RUN apt-get update -qq && \
     apt-get install -y vim telnet git
@@ -11,8 +11,10 @@ COPY ./helloworld.proto /etc/proto/helloworld.proto
 
 ## install basic google's protobuf files
 RUN cd /opt && \
-    curl -OL https://github.com/google/protobuf/releases/download/v3.9.0/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
-    unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local/protoc
+    curl -OL https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local/protoc && \
+    find /usr/local/protoc -type d -exec chmod 755 {} \; && \
+    find /usr/local/protoc/include -type f -exec chmod 644 {} \;
 
 RUN luarocks install lua-resty-grpc-gateway
 RUN luarocks install serpent


### PR DESCRIPTION
Bump protoc to 3.11.0.

From 3.10.0, protoc release package file permission is changed.
So, add chmod command in Dockerfile.

If you did not chown, the following error message appears.
```
$ sudo docker-compose up
Creating network "example_grpc-gateway" with the default driver
Creating example_server_1  ... done
Creating example_gateway_1 ... done
Attaching to example_server_1, example_gateway_1
gateway_1  | 2019/11/27 11:09:01 [alert] 1#1: lua_code_cache is off; this will hurt performance in /etc/nginx/conf.d/server.conf:1
gateway_1  | nginx: [alert] lua_code_cache is off; this will hurt performance in /etc/nginx/conf.d/server.conf:1
gateway_1  | 2019/11/27 11:09:03 [error] 6#6: *1 [lua] util.lua:22: find_method(): /etc/proto/helloworld.proto, client: 172.21.0.1, server: localhost, request: "GET /rest?name=grpc-rest HTTP/1.1", host: "localhost:9000"
gateway_1  | 2019/11/27 11:09:03 [error] 6#6: *1 lua entry thread aborted: runtime error: ...cal/openresty/luajit/share/lua/5.1/grpc-gateway/util.lua:24: attempt to index local 'loaded' (a boolean value)
gateway_1  | stack traceback:
gateway_1  | coroutine 0:
gateway_1  |    ...cal/openresty/luajit/share/lua/5.1/grpc-gateway/util.lua: in function 'find_method'
gateway_1  |    .../openresty/luajit/share/lua/5.1/grpc-gateway/request.lua:19: in function 'transform'
gateway_1  |    access_by_lua(server.conf:42):10: in main chunk, client: 172.21.0.1, server: localhost, request: "GET /rest?name=grpc-rest HTTP/1.1", host: "localhost:9000"
gateway_1  | 172.21.0.1 - - [27/Nov/2019:11:09:03 +0000] "GET /rest?name=grpc-rest HTTP/1.1" 500 0 "-" "curl/7.58.0"
gateway_1  | 2019/11/27 11:09:03 [error] 6#6: *1 [lua] util.lua:22: find_method(): /etc/proto/helloworld.proto, client: 172.21.0.1, server: localhost, request: "GET /rest?name=grpc-rest HTTP/1.1", host: "localhost:9000"
gateway_1  | 2019/11/27 11:09:03 [error] 6#6: *1 failed to run body_filter_by_lua*: ...cal/openresty/luajit/share/lua/5.1/grpc-gateway/util.lua:24: attempt to index local 'loaded' (a boolean value)
gateway_1  | stack traceback:
gateway_1  |    ...cal/openresty/luajit/share/lua/5.1/grpc-gateway/util.lua:24: in function 'find_method'
gateway_1  |    ...openresty/luajit/share/lua/5.1/grpc-gateway/response.lua:17: in function 'transform'
gateway_1  |    body_filter_by_lua:10: in main chunk, client: 172.21.0.1, server: localhost, request: "GET /rest?name=grpc-rest HTTP/1.1", host: "localhost:9000"
```


https://github.com/protocolbuffers/protobuf/releases/download/v3.9.0/protoc-3.9.0-linux-x86_64.zip
```
$ ls -alR
.:
total 20
drwxrwxr-x 4 kmasuda kmasuda 4096 11月 27 10:52 .
drwxrwxr-x 7 kmasuda kmasuda 4096 11月 27 11:10 ..
drwxr-xr-x 2 kmasuda kmasuda 4096  7月 12 16:18 bin
drwxr-xr-x 3 kmasuda kmasuda 4096  7月 12 16:18 include
-rw-r--r-- 1 kmasuda kmasuda  724  7月 12 16:18 readme.txt

./bin:
total 4864
drwxr-xr-x 2 kmasuda kmasuda    4096  7月 12 16:18 .
drwxrwxr-x 4 kmasuda kmasuda    4096 11月 27 10:52 ..
-rwxr-xr-x 1 kmasuda kmasuda 4969752  7月 12 00:41 protoc

./include:
total 12
drwxr-xr-x 3 kmasuda kmasuda 4096  7月 12 16:18 .
drwxrwxr-x 4 kmasuda kmasuda 4096 11月 27 10:52 ..
drwxr-xr-x 3 kmasuda kmasuda 4096  7月 12 16:18 google

./include/google:
total 12
drwxr-xr-x 3 kmasuda kmasuda 4096  7月 12 16:18 .
drwxr-xr-x 3 kmasuda kmasuda 4096  7月 12 16:18 ..
drwxr-xr-x 3 kmasuda kmasuda 4096  7月 12 16:18 protobuf

./include/google/protobuf:
total 116
drwxr-xr-x 3 kmasuda kmasuda  4096  7月 12 16:18 .
drwxr-xr-x 3 kmasuda kmasuda  4096  7月 12 16:18 ..
-rw-r--r-- 1 kmasuda kmasuda  5878  7月 12 16:18 any.proto
-rw-r--r-- 1 kmasuda kmasuda  7734  7月 12 16:18 api.proto
drwxr-xr-x 2 kmasuda kmasuda  4096  7月 12 16:18 compiler
-rw-r--r-- 1 kmasuda kmasuda 36675  7月 12 16:18 descriptor.proto
-rw-r--r-- 1 kmasuda kmasuda  4889  7月 12 16:18 duration.proto
-rw-r--r-- 1 kmasuda kmasuda  2422  7月 12 16:18 empty.proto
-rw-r--r-- 1 kmasuda kmasuda  8206  7月 12 16:18 field_mask.proto
-rw-r--r-- 1 kmasuda kmasuda  2352  7月 12 16:18 source_context.proto
-rw-r--r-- 1 kmasuda kmasuda  3780  7月 12 16:18 struct.proto
-rw-r--r-- 1 kmasuda kmasuda  6200  7月 12 16:18 timestamp.proto
-rw-r--r-- 1 kmasuda kmasuda  6129  7月 12 16:18 type.proto
-rw-r--r-- 1 kmasuda kmasuda  4035  7月 12 16:18 wrappers.proto

./include/google/protobuf/compiler:
total 20
drwxr-xr-x 2 kmasuda kmasuda 4096  7月 12 16:18 .
drwxr-xr-x 3 kmasuda kmasuda 4096  7月 12 16:18 ..
-rw-r--r-- 1 kmasuda kmasuda 8201  7月 12 16:18 plugin.proto
```

https://github.com/protocolbuffers/protobuf/releases/download/v3.11.0/protoc-3.11.0-linux-x86_64.zip
```
.:
total 20
drwxrwxr-x 4 kmasuda kmasuda 4096 11月 27 11:20 .
drwxrwxr-x 7 kmasuda kmasuda 4096 11月 27 11:10 ..
drwxr-x--- 2 kmasuda kmasuda 4096 11月 26 01:20 bin
drwxr-x--- 3 kmasuda kmasuda 4096 11月 26 01:20 include
-rw-r----- 1 kmasuda kmasuda  724 11月 26 01:20 readme.txt

./bin:
total 4960
drwxr-x--- 2 kmasuda kmasuda    4096 11月 26 01:20 .
drwxrwxr-x 4 kmasuda kmasuda    4096 11月 27 11:20 ..
-rwxr-x--- 1 kmasuda kmasuda 5068728 11月 26 00:53 protoc

./include:
total 12
drwxr-x--- 3 kmasuda kmasuda 4096 11月 26 01:20 .
drwxrwxr-x 4 kmasuda kmasuda 4096 11月 27 11:20 ..
drwxr-x--- 3 kmasuda kmasuda 4096 11月 26 01:20 google

./include/google:
total 12
drwxr-x--- 3 kmasuda kmasuda 4096 11月 26 01:20 .
drwxr-x--- 3 kmasuda kmasuda 4096 11月 26 01:20 ..
drwxr-x--- 3 kmasuda kmasuda 4096 11月 26 01:20 protobuf

./include/google/protobuf:
total 112
drwxr-x--- 3 kmasuda kmasuda  4096 11月 26 01:20 .
drwxr-x--- 3 kmasuda kmasuda  4096 11月 26 01:20 ..
-rw-r----- 1 kmasuda kmasuda  5878 11月 26 01:20 any.proto
-rw-r----- 1 kmasuda kmasuda  7734 11月 26 01:20 api.proto
drwxr-x--- 2 kmasuda kmasuda  4096 11月 26 01:20 compiler
-rw-r----- 1 kmasuda kmasuda 36675 11月 26 01:20 descriptor.proto
-rw-r----- 1 kmasuda kmasuda  4888 11月 26 01:20 duration.proto
-rw-r----- 1 kmasuda kmasuda  2422 11月 26 01:20 empty.proto
-rw-r----- 1 kmasuda kmasuda  8192 11月 26 01:20 field_mask.proto
-rw-r----- 1 kmasuda kmasuda  2352 11月 26 01:20 source_context.proto
-rw-r----- 1 kmasuda kmasuda  3780 11月 26 01:20 struct.proto
-rw-r----- 1 kmasuda kmasuda  6200 11月 26 01:20 timestamp.proto
-rw-r----- 1 kmasuda kmasuda  6129 11月 26 01:20 type.proto
-rw-r----- 1 kmasuda kmasuda  4035 11月 26 01:20 wrappers.proto

./include/google/protobuf/compiler:
total 20
drwxr-x--- 2 kmasuda kmasuda 4096 11月 26 01:20 .
drwxr-x--- 3 kmasuda kmasuda 4096 11月 26 01:20 ..
-rw-r----- 1 kmasuda kmasuda 8201 11月 26 01:20 plugin.proto
```