### PR TITLE
Add te header to example conf

### DIFF
--- a/example/gateway/conf/server.conf
+++ b/example/gateway/conf/server.conf
@@ -59,6 +59,7 @@ server {
       ngx.header["Content-Type"] = "application/json"
     }
 
+    grpc_set_header TE trailers;
     grpc_set_header Content-Type application/grpc;
     grpc_pass backend:50001;
   }


### PR DESCRIPTION
Except golang backend, proxy is not work properly or warning.

Python Backend (nginx error log)
```
2019/11/27 11:42:29 [error] 4553#4553: *1 upstream rejected request with error 2 while reading response header from upstream, client: 127.0.0.1, server: 127.0.0.1, request: "GET /rest?name=grpc-rest HTTP/1.1", upstream: "grpc://192.168.99.100:50051", host: "localhost"
```

Java Backend
```
Nov 27, 2019 11:46:37 AM io.grpc.netty.NettyServerHandler onHeadersRead
WARNING: Expected header TE: trailers, but null is received. This means some intermediate proxy may not support trailers
```

It works fine by adding `grpc_set_header TE trailers;`.