### PR TITLE
Do not use pcall in order to catch an error

### DIFF
--- a/grpc-gateway/proto.lua
+++ b/grpc-gateway/proto.lua
@@ -29,10 +29,9 @@ _M.new = function(proto_file, ...)
   -- and protoc library should resolve imports automatically.
   _p.include_imports = true
 
-  -- We'd like to load inside pcall due to prevent duplicate load error
-  pcall(function()
-    _p:loadfile(proto_file)
-  end)
+  -- below function may throw error when it fails to load proto file.
+  _p:loadfile(proto_file)
+
   local instance = {}
   instance.get_loaded_proto = function()
     return _p.loaded


### PR DESCRIPTION
Related https://github.com/ysugimoto/lua-resty-grpc-gateway/issues/21

When `protoc` tries to load protobuf file which user-supplied but it fails, we should raise an error in order to catch what causes.

Before:

```
pcall(func()
  _p.loadfile(proto_file)
end)
```

After:

```
_p.loadfile(proto_file) -- unwrapped
```

If we failed to load proto file, the gateway will not work properly in any case.